### PR TITLE
arrange-distorted-content-on-forum-page

### DIFF
--- a/client/src/pages/forum/Forum.jsx
+++ b/client/src/pages/forum/Forum.jsx
@@ -112,13 +112,13 @@ const Forum = () => {
                                     <div className='capitalize text-base md:text-2xl font-semibold'>
                                         <p>{detail.title}</p>
                                     </div>
-                                    <div className='absolute left-0 md:static flex flex-col md:flex-row md:gap-5 text-[#bababa] text-sm md:text-base'>
+                                    <div className='absolute mt-4 sm:mt-0 left-0 sm:static flex flex-col sm:flex-row sm:gap-5 text-[#bababa] text-sm md:text-base'>
                                         <p>{detail.name}</p>
                                         <p>{detail.date}</p>
                                     </div>
                                 </div>
                             </div>
-                            <div className='flex flex-col md:flex-row gap-5 mt-8 md:mt-0 mb-5'>
+                            <div className='flex flex-col md:flex-row gap-5 mt-12 sm:mt-0 mb-5'>
                                 <div className='basis-4/5'>
                                     <p className='text-base text-[#6d6d6d]'>
                                         {detail.content}
@@ -146,9 +146,9 @@ const Forum = () => {
                 <p>1 - 8 of 45 Discussions</p>
             </div>
             <div className='flex gap-5'>
-                <button className='border-r border-[#bababa] px-5 btn text-disabledDisabled'> <span className='align-middle'>&lt;Previous</span></button>
+                <button className='border-r border-[#bababa] px-5 btn text-disabledDisabled'><span className='align-middle'>&lt;Previous</span></button>
 
-                <div className='hidden md:flex gap-8'>
+                <div className='hidden md:flex md:gap-2 lg:gap-8'>
                     <button className='btn btnSecondary'>1</button>
                     <button className='btn text-primaryMain'>2</button>
                     <button className='btn text-primaryMain'>3</button>


### PR DESCRIPTION
# General Changes

-   Fixes distortion of images and text of forum posts on the forum page.
-   Fixes overflow of `Next` and `Previous` buttons.
-   …
## Developer Notes

Add any notes here that may be helpful for reviewers.

---
Linear ticket: https://linear.app/team-chisel-hng9/issue/FE-34/arrange-distorted-content-on-forum-page

## Checklist

-   [x] The base branch is set to `dev`
-   [x] The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
-   [x] The Linear issue has been linked to the PR
-   [x] The General Changes section has been filled out
-   [x] Developer Notes have been added (optional)
-   [ ] End-to-end tests(if any) are passing without any errors
-   [x] Code style generally follows existing patterns
-   [ ] New third-party packages, if any, do not introduce potential security threats
-   [ ] There are no CI changes, or they have been OK’d by the devops team
-   [ ] Code changes have been quality checked in the ephemeral URL
-   [ ] Errors are handled using the right error handles
-   [ ] The right thing is returned
