### PR TITLE
Feat(FE-57): add scroll to top to all pages on mobile

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -2,6 +2,7 @@ import React from "react";
 import "./App.css";
 import Event from "./pages/Event";
 import "react-toastify/dist/ReactToastify.css";
+import MbScrollToTopBtn from "./Components/MbScrollToTopBtn";
 
 import {
 	Register,
@@ -155,6 +156,8 @@ const App = () => {
 					<Route path="*" element={<ErrorPage />} />
 				</Routes>
 				<ToastContainer position="top-center"></ToastContainer>
+
+				<MbScrollToTopBtn />
 
 				<Footer />
 			</ScrollToTop>

--- a/client/src/Components/MbScrollToTopBtn.jsx
+++ b/client/src/Components/MbScrollToTopBtn.jsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { useEffect, useState } from "react";
+import { ReactComponent as ArrowBlue } from "../Assets/arrow-up-blue.svg";
+
+export default function MbScrollToTopBtn() {
+    const [displayArrow, setDisplayArrow] = useState(false);
+
+	const scrollUp = () => {
+		window.scrollTo({ top: 0, left: 0, behavior: "smooth" });
+	};
+
+	const listenToScroll = () => {
+		if (
+			document.body.scrollTop > 50 ||
+			document.documentElement.scrollTop > 50
+		) {
+			setDisplayArrow(true);
+		} else {
+			setDisplayArrow(false);
+		}
+	};
+
+	useEffect(() => {
+		window.addEventListener("scroll", listenToScroll);
+		return () => window.removeEventListener("scroll", listenToScroll);
+	}, []);
+
+  return (
+    <div>
+        {displayArrow && (
+            <ArrowBlue
+                className="fixed bottom-[40px] right-[5px] md:hidden"
+                onClick={scrollUp}
+            />
+		)}
+    </div>
+  )
+}


### PR DESCRIPTION
# General Changes

-   Adds scroll to top button component for mobile only
-   Adds scroll to top component to all pages for mobile devices

## Developer Notes

Linear Ticket: https://linear.app/team-chisel-hng9/issue/FE-57/add-back-to-top-button-to-some-pages-and-all-pages-on-mobile

---

## Checklist

-   [x] The base branch is set to `dev`
-   [x] The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
-   [x] The Linear issue has been linked to the PR
-   [x] The General Changes section has been filled out
-   [x] Developer Notes have been added (optional)
-   [ ] End-to-end tests(if any) are passing without any errors
-   [x] Code style generally follows existing patterns
-   [ ] New third-party packages, if any, do not introduce potential security threats
-   [ ] There are no CI changes, or they have been OK’d by the devops team
-   [ ] Code changes have been quality checked in the ephemeral URL
-   [ ] Errors are handled using the right error handles
-   [ ] The right thing is returned
