### PR TITLE
feat/BE38 fixed a bug in the delete admin endpoint

### DIFF
--- a/server/controllers/adminController.js
+++ b/server/controllers/adminController.js
@@ -75,7 +75,7 @@ const deleteAdmin = async (req,res) => {
 	   throw new BadRequestError(`user does not exist`)
    }
    
-   if(req.user.role !== "Lead-admin" && admin._id != req.user.id) {
+   if(req.user.role !== "Lead-admin" && admin._id != req.user.userId) {
 	   throw new UnauthenticatedError(`you are not authorized to carry out this operation`)
    }
 


### PR DESCRIPTION
Linear link: https://linear.app/team-chisel-hng9/issue/BE-38/delete-an-admin-endpoint

an endpoint to delete an admin either by the lead admin or the logged-in admin