### PR TITLE
Feat/be-79/limit and format gpt 3 output

### DIFF
--- a/server/controllers/coverLetterGenerator.js
+++ b/server/controllers/coverLetterGenerator.js
@@ -1,5 +1,9 @@
-const { generator } = require("../utils/gpt3.generate");
-const { StatusCodes } = require("http-status-codes");
+const {
+	generator
+} = require("../utils/gpt3.generate");
+const {
+	StatusCodes
+} = require("http-status-codes");
 
 const sendCoverLetter = async (req, res) => {
 	const {
@@ -23,6 +27,11 @@ const sendCoverLetter = async (req, res) => {
 		recipient_name,
 		recipient_department
 	);
+	if (!coverLetter) {
+		return res.status(StatusCodes.BAD_REQUEST).json({
+			message: 'Max resume text content, Upload summarized resume!'
+		})
+	}
 	const response = {
 		status: "success",
 		data: {
@@ -42,4 +51,6 @@ const sendCoverLetter = async (req, res) => {
 	return res.status(StatusCodes.CREATED).json(response);
 };
 
-module.exports = { sendCoverLetter };
+module.exports = {
+	sendCoverLetter
+};

--- a/server/utils/gpt3.generate.js
+++ b/server/utils/gpt3.generate.js
@@ -21,7 +21,7 @@ const generator = async (
 	});
 	const openai = new OpenAIApi(configuration);
 
-	const gpt3Prompt = `With a Limit of 250 words, Use this resume ${resume}, to generate a cover letter for the role of ${role} at ${company_name}. Address it to ${recipient_name} in the ${recipient_department}of the organization `;
+	const gpt3Prompt = `With a Limit of 350 words, Use this resume ${resume}, to generate a cover letter for the role of ${role} at ${company_name}. Address it to ${recipient_name} in the ${recipient_department}of the organization `;
 	if (gpt3Prompt.length > 25000) return false
 	const response = await openai.createCompletion({
 		model: "text-davinci-002",

--- a/server/utils/gpt3.generate.js
+++ b/server/utils/gpt3.generate.js
@@ -1,6 +1,11 @@
 require("dotenv").config();
-const { Configuration, OpenAIApi } = require("openai");
-const { getpdfTotext } = require("./pdfToString");
+const {
+	Configuration,
+	OpenAIApi
+} = require("openai");
+const {
+	getpdfTotext
+} = require("./pdfToString");
 
 const generator = async (
 	file,
@@ -16,19 +21,20 @@ const generator = async (
 	});
 	const openai = new OpenAIApi(configuration);
 
-	const gpt3Prompt = `Use this resume ${resume}, to generate a cover letter for the role of ${role} at ${company_name}. Address it to ${recipient_name} in the ${recipient_department}of the organization `;
-	// create the prompt with the function parameters
+	const gpt3Prompt = `With a Limit of 250 words, Use this resume ${resume}, to generate a cover letter for the role of ${role} at ${company_name}. Address it to ${recipient_name} in the ${recipient_department}of the organization `;
+	if (gpt3Prompt.length > 25000) return false
 	const response = await openai.createCompletion({
 		model: "text-davinci-002",
 		prompt: gpt3Prompt,
 		temperature: 0.5,
-		max_tokens: 2040,
+		max_tokens: 4000,
 		top_p: 1,
 		frequency_penalty: 0,
 		presence_penalty: 0,
 	});
 	const coverLetter = response.data.choices[0].text;
 	return coverLetter;
+
 };
 module.exports = {
 	generator,


### PR DESCRIPTION
# General Changes
Limit output length to a 350 word limit
Handled potential error case of max gpt-3 model tokens exceeded


Linear: https://linear.app/team-chisel-hng9/issue/BE-77/refactor-the-gpt-3-processing-for-error-case-completion
Linear: https://linear.app/team-chisel-hng9/issue/BE-79/limit-content-output-by-gpt3

---

## Checklist

-   [ ] The base branch is set to `dev`
-   [ ] The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
-   [ ] The Linear issue has been linked to the PR
-   [ ] The General Changes section has been filled out
-   [ ] Developer Notes have been added (optional)
-   [ ] End-to-end tests(if any) are passing without any errors
-   [ ] Code style generally follows existing patterns
-   [ ] New third-party packages, if any, do not introduce potential security threats
-   [ ] There are no CI changes, or they have been OK’d by the devops team
-   [ ] Code changes have been quality checked in the ephemeral URL
-   [ ] Errors are handled using the right error handles
-   [ ] The right thing is returned
