### PR TITLE
feat(BE-79): Limit output to 350 words

### DIFF
--- a/server/utils/gpt3.generate.js
+++ b/server/utils/gpt3.generate.js
@@ -1,6 +1,11 @@
 require("dotenv").config();
-const { Configuration, OpenAIApi } = require("openai");
-const { getpdfTotext } = require("./pdfToString");
+const {
+	Configuration,
+	OpenAIApi
+} = require("openai");
+const {
+	getpdfTotext
+} = require("./pdfToString");
 
 const generator = async (
 	file,
@@ -16,8 +21,7 @@ const generator = async (
 	});
 	const openai = new OpenAIApi(configuration);
 
-	const gpt3Prompt = `Use this resume ${resume}, to generate a cover letter for the role of ${role} at ${company_name}. Address it to ${recipient_name} in the ${recipient_department}of the organization `;
-	// create the prompt with the function parameters
+	const gpt3Prompt = `While not exceeding 350 words, Use this resume ${resume}, to generate a cover letter for the role of ${role} at ${company_name}. Address it to ${recipient_name} in the ${recipient_department}of the organization `;
 	const response = await openai.createCompletion({
 		model: "text-davinci-002",
 		prompt: gpt3Prompt,


### PR DESCRIPTION
# General Changes

Changed GPT-3 prompt to limit output to <350 words
This was done to prevent overflow during preview on the client side




## Checklist

-   [ ] The base branch is set to `dev`
-   [ ] The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
-   [ ] The Linear issue has been linked to the PR
-   [ ] The General Changes section has been filled out
-   [ ] Developer Notes have been added (optional)
-   [ ] End-to-end tests(if any) are passing without any errors
-   [ ] Code style generally follows existing patterns
-   [ ] New third-party packages, if any, do not introduce potential security threats
-   [ ] There are no CI changes, or they have been OK’d by the devops team
-   [ ] Code changes have been quality checked in the ephemeral URL
-   [ ] Errors are handled using the right error handles
-   [ ] The right thing is returned
