### PR TITLE
Fix/(BE-59) Middleware to upload image to blog

### DIFF
--- a/server/middleware/image.js
+++ b/server/middleware/image.js
@@ -7,16 +7,23 @@ const BadRequestError = require("../errors/bad-request");
 
 const uploadImage = async (req, res, next) => {
 	try {
-		const file = req.files.myFile;
-		const upload = await cloudinary.uploader.upload(file.tempFilePath, {
-			public_id: `${Date.now()}`,
-			resource_type: "auto",
-			folder: "images",
-		});
-		req.upload = {
-			public_id: upload.public_id,
-			url: upload.url,
-		};
+		if (req.files) {
+			const file = req.files.myFile;
+			const upload = await cloudinary.uploader.upload(file.tempFilePath, {
+				public_id: `${Date.now()}`,
+				resource_type: "auto",
+				folder: "images",
+			});
+			req.upload = {
+				public_id: upload.public_id,
+				url: upload.url,
+			};
+		} else {
+			req.upload = {
+				public_id: null,
+				url: null,
+			};
+		}
 		next();
 	} catch (err) {
 		throw new BadRequestError("Failed to upload the image");

--- a/server/models/Blog.js
+++ b/server/models/Blog.js
@@ -35,13 +35,13 @@ const BlogSchema = new Schema(
 			type: String,
 			required: false,
 			maxlength: 255,
-			default: "",
+			default: null,
 		},
 		imageCloudinaryId: {
 			type: String,
 			required: false,
 			maxlength: 255,
-			default: "",
+			default: null,
 		},
 		replies: [
 			{


### PR DESCRIPTION
# General Changes

-   Added null as the default value to the blog model for image cloudinary id and image url
-   Added statement to check if a file was sent to the backend

## Developer Notes

If the frontend needs an image to be sent, an image will be uploaded or if not it would not se added to the database

## Linear link
https://linear.app/team-chisel-hng9/issue/BE-59/middleware-to-upload-image-to-blog

## Checklist

-   [x] The base branch is set to `dev`
-   [x] The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
-   [x] The Linear issue has been linked to the PR
-   [x] The General Changes section has been filled out
-   [x] Developer Notes have been added (optional)
-   [ ] End-to-end tests(if any) are passing without any errors
-   [x] Code style generally follows existing patterns
-   [ ] New third-party packages, if any, do not introduce potential security threats
-   [x] There are no CI changes, or they have been OK’d by the devops team
-   [x] Code changes have been quality checked in the ephemeral URL
-   [x] Errors are handled using the right error handles
-   [x] The right thing is returned
