### PR TITLE
feat(FE-124): Changed '2022 Cover' to '2022 Coverly'

### DIFF
--- a/client/src/Layouts/Footer.jsx
+++ b/client/src/Layouts/Footer.jsx
@@ -62,7 +62,7 @@ const Footer = () => {
 			<div className="bg-[#F2F2F7] px-24 py-[18px] max-[767px]:px-14 max-[425px]:px-8 max-[425px]:wrap max-[366px]:gap-28">
 				<div className="flex justify-between text-[12px] text-grey400 flex-wrap max-[425px]:gap-4">
 					<p className="max-[425px]:mr-20 max-[340px]:mr-0">
-						© 2022 Cover. All rights reserved.
+						© 2022 Coverly. All rights reserved.
 					</p>
 					<Link to="/terms-and-conditions" className="block  ">
 						Terms and Conditions


### PR DESCRIPTION
# General Changes

-   Fixed spelling issue in the copyright aspect of the footer.
- Changed 2022 Cover to 2022 Coverly

## Linear Link
https://linear.app/team-chisel-hng9/issue/FE-124/change-2022-cover-to-2022-coverly

## Checklist

-   [x] The base branch is set to `dev`
-   [x] The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
-   [x] The Linear issue has been linked to the PR
-   [x] The General Changes section has been filled out
-   [x] Developer Notes have been added (optional)
-   [x] End-to-end tests(if any) are passing without any errors
-   [x] Code style generally follows existing patterns
-   [x] New third-party packages, if any, do not introduce potential security threats
-   [x] There are no CI changes, or they have been OK’d by the devops team
-   [x] Code changes have been quality checked in the ephemeral URL
-   [x] Errors are handled using the right error handles
-   [x] The right thing is returned

![image](https://user-images.githubusercontent.com/104460178/206356639-7d81d6f9-d9c0-4d98-9996-420da1fe348a.png)

