### PR TITLE
fix[FE-128]: Retrieve user data from server to override cache at startup

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -43,8 +43,60 @@ import { ScrollToTop } from "./Components";
 import { Header, Footer } from "./Layouts";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import { ToastContainer } from "react-toastify";
+import { useGlobalContext } from "./context/context";
+import { addUserToLocalStorage, addEmailToLocalStorage } from "./Utils/localStorage";
+import axios from "axios"
+import { toast } from "react-toastify";
 
 const App = () => {
+	const {user, setUser, setUserEmail} = useGlobalContext()
+
+	React.useEffect(() => {
+		let loading = true
+		const getUser = async () =>  {
+			if (!user?.token || !user?.userId) return
+			try {
+				const res = await axios.get(
+					`https://api.coverly.hng.tech/api/v1/auth/dashboard/${user.userId}`,
+					{
+						headers: {
+							Authorization: `Bearer ${user.token}`,
+						},
+					}
+				);
+				if (loading) {
+					const userObj = {
+						name: res.data.name,
+						email: res.data.email,
+						jobRole: res.data.jobRole,
+						userId: user.userId,
+						token: user.token,
+					};
+					addUserToLocalStorage(userObj);
+					setUser(userObj);
+					addEmailToLocalStorage(res.data.email);
+					setUserEmail(res.data.email)
+				}
+			} catch (error) {
+				console.error("ERROR RETRIEVING USER DATA FROM SERVER", error)
+				if (error.code === "ERR_NETWORK") {
+					toast.error("Error retrieving user data from Server")
+				} else {
+				addUserToLocalStorage(null);
+				setUser({});
+				addEmailToLocalStorage("");
+				setUserEmail("")
+				}
+			}
+			loading = false
+		}
+		getUser()
+	  return () => {
+		loading = false
+	  }
+	  // eslint-disable-next-line
+	}, [])
+	
 	return (
 		<Router>
 			<ScrollToTop>

--- a/client/src/pages/SignIn.jsx
+++ b/client/src/pages/SignIn.jsx
@@ -8,12 +8,13 @@ import { Link } from "react-router-dom";
 import axios from "axios";
 import { toast } from "react-toastify";
 import { useGlobalContext } from "../context/context";
-import { addUserToLocalStorage } from "../Utils/localStorage";
+import { addUserToLocalStorage, addEmailToLocalStorage } from "../Utils/localStorage";
 import { useNavigate } from "react-router-dom";
 import { useState } from "react";
 import GoogleAuth from "../Layouts/GoogleAuth";
+
 const Login = () => {
-	const { setUser } = useGlobalContext();
+	const { setUser, setUserEmail } = useGlobalContext();
 	const [passwordShown, setPasswordShown] = useState(false);
 	const navigate = useNavigate();
 	const LoginSchema = Yup.object().shape({
@@ -46,11 +47,14 @@ const Login = () => {
 			const user = {
 				name: UserDetails.data.name,
 				email: UserDetails.data.email,
+				jobRole: UserDetails.data.jobRole,
 				userId: resp.data.user,
 				token: resp.data.token,
 			};
 			addUserToLocalStorage(user);
 			setUser(user);
+			addEmailToLocalStorage(UserDetails.data.email);
+			setUserEmail(UserDetails.data.email)
 			toast.success(`Welcome Back ${UserDetails.data.name}`);
 			navigate("/");
 		} catch (err) {


### PR DESCRIPTION
# General Changes

-   Updates cached user data from the server at startup
-   Adds jobRole user parameter and cache email at sign in page
-   …

## Developer Notes

This PR resolves the ticket https://linear.app/team-chisel-hng9/issue/FE-128/retrieve-user-data-from-server-to-override-cache-at-startup

---

## Checklist

-   [x] The base branch is set to `dev`
-   [x] The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
-   [x] The Linear issue has been linked to the PR
-   [x] The General Changes section has been filled out
-   [x] Developer Notes have been added (optional)
-   [x] End-to-end tests(if any) are passing without any errors
-   [x] Code style generally follows existing patterns
-   [x] New third-party packages, if any, do not introduce potential security threats
-   [x] There are no CI changes, or they have been OK’d by the DevOps team
-   [x] Code changes have been quality-checked in the ephemeral URL
-   [x] Errors are handled using the right error handles
-   [x] The right thing is returned
