### PR TITLE
Feat/resume-controllers

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -37,6 +37,7 @@ const forumRoutes = require("./routes/forumRoutes");
 const adminDashboard = require("./routes/adminDashboard");
 const customerStoriesRoutes = require("./routes/customerStoriesRoutes");
 const ReplyBlogRoute = require("./routes/replyBlogRoutes");
+const resumeRoute = require("./routes/resume");
 
 //Passport config
 require("./utils/passport")(passport);
@@ -91,6 +92,7 @@ app.use("/api/v1", contactRoutes);
 app.use("/api/v1/forum", forumRoutes);
 app.use("/api/v1/auth", authRoutes);
 app.use("/api/v1/", ReplyBlogRoute);
+app.use("/api/v1/resume", resumeRoute);
 
 app.get("/", (req, res) => {
 	res.send("templates api");

--- a/server/controllers/resume.js
+++ b/server/controllers/resume.js
@@ -1,0 +1,104 @@
+//Need function to save and get single resume in text/string format
+//Actions can only be carried out by authenticated users
+//Cover letter generate function needs to be modified accordingly
+
+//What is the flow for saving resume -- Whenever user attempts generation from  original generation page if the user is signed in, user will be given the option to save the current cv
+
+const resumeDB = require("../models/resume");
+const { StatusCodes } = require("http-status-codes");
+const { NotFoundError } = require("../errors");
+
+//Function to return errors for this controller - Dry coding
+const errorRes = (res, error) => {
+	return res.status(StatusCodes.BAD_REQUEST).json({
+		status: "fail",
+		message: error.message,
+	});
+};
+
+const saveResume = async (req, res, next) => {
+	try {
+		//Research better alternates to enforce storage restrictions
+		const savedResumes = await resumeDB.find({ user_id: req.user.userId });
+		//This check below has to be modified to meet app requirements, maybe based on payment plans later on
+		if (savedResumes.length === 3 /*Condition to be reviewed*/) {
+			return res.status(StatusCodes.FORBIDDEN).json({
+				status: "fail",
+				message:
+					"Already at maximum storage, Upgrade or delete to store more",
+			});
+		}
+		const resume = await resumeDB.create({
+			user_id: req.user.userId,
+			content: req.body.content,
+			label: req.body.label,
+		});
+		res.status(StatusCodes.CREATED).json({
+			status: "success",
+			message: "Resume saved successfully",
+		});
+	} catch (error) {
+		errorRes(res, error);
+	}
+};
+
+const getResume = async (req, res, next) => {
+	try {
+		const resume = await resumeDB.findById(req.params.id);
+		if (!resume) {
+			throw new NotFoundError("Requested resume does not exist");
+		}
+		res.status(StatusCodes.OK).json({
+			status: "success",
+			data: resume,
+		});
+	} catch (error) {
+		errorRes(res, error);
+	}
+};
+
+const getAllresumes = async (req, res, next) => {
+	try {
+		const resumes = await resumeDB.find({ user_id: req.user.userId });
+		//Check returned length for empty resume - Can be empty if user has no saved resume or if user does not exist(Should not arise because route is protected)
+		if (resumes.length === 0) {
+			return res.status(404).json({
+				status: "success",
+				message: "No resumes for this user",
+			});
+		} else if (resumes.length > 0) {
+			res.status(StatusCodes.OK).json({
+				status: "success",
+				data: {
+					resumes,
+				},
+			});
+		}
+	} catch (error) {
+		errorRes(res, error);
+	}
+};
+
+const delResume = async (req, res, next) => {
+	try {
+		const resume = await resumeDB.findByIdAndDelete(req.params.id);
+
+		if (!resume) {
+			throw new NotFoundError("Requested resume does not exist");
+		}
+
+		res.status(204).json({
+			status: "fail",
+			message: "Deleted",
+		});
+	} catch (error) {
+		errorRes(res, error);
+	}
+};
+
+module.exports = {
+	saveResume,
+	getResume,
+	delResume,
+	getAllresumes,
+};

--- a/server/models/resume.js
+++ b/server/models/resume.js
@@ -1,0 +1,13 @@
+const mongoose = require("mongoose");
+
+const resumeSchema = new mongoose.Schema({
+	user_id: {
+		type: mongoose.Types.ObjectId,
+		ref: "User",
+		required: [true, "Please provide user"],
+	},
+	content: String,
+    label: String
+});
+
+module.exports = mongoose.model("resume", resumeSchema);

--- a/server/models/resume.js
+++ b/server/models/resume.js
@@ -6,8 +6,8 @@ const resumeSchema = new mongoose.Schema({
 		ref: "User",
 		required: [true, "Please provide user"],
 	},
-	content: String,
-    label: String
+	content: String, //Make Unique? I do not know how efficient our pdf parser is.
+	label: String, //Was thinking of making this unique - Label here refers to the filename (Will not make unique because it is entirely possible for twi different resumes to be named the same way)
 });
 
 module.exports = mongoose.model("resume", resumeSchema);

--- a/server/routes/resume.js
+++ b/server/routes/resume.js
@@ -1,0 +1,17 @@
+const express = require("express");
+const {
+	saveResume,
+	getAllresumes,
+	getResume,
+	delResume,
+} = require("../controllers/resume");
+const auth = require("../middleware/authentication");
+
+const router = express.Router();
+
+// router.use(auth);
+
+router.route("/").delete(delResume).get(getAllresumes).post(saveResume);
+router.route("/:id").get(getResume);
+
+module.exports = router;

--- a/server/routes/resume.js
+++ b/server/routes/resume.js
@@ -9,9 +9,9 @@ const auth = require("../middleware/authentication");
 
 const router = express.Router();
 
-// router.use(auth);
+router.use(auth);
 
-router.route("/").delete(delResume).get(getAllresumes).post(saveResume);
-router.route("/:id").get(getResume);
+router.route("/").get(getAllresumes).post(saveResume);
+router.route("/:id").get(getResume).delete(delResume);
 
 module.exports = router;


### PR DESCRIPTION
# General Changes

- Added feature to save resume, get a resume, get all resumes by user and also delete a resume


## Developer Notes

- In the delResume function of the resume controller, I made a comment about a needed restriction I may need to modify.
- There needs to be a modification to the upload resume function to aid the client side devs save resume (file name needs to be returned)
- Made some comments in the resume controller and model for potential future modifications

---

## Checklist

-   [ ] The base branch is set to `dev`
-   [ ] The title is using [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) formatting
-   [ ] The Linear issue has been linked to the PR
-   [ ] The General Changes section has been filled out
-   [ ] Developer Notes have been added (optional)
-   [ ] End-to-end tests(if any) are passing without any errors
-   [ ] Code style generally follows existing patterns
-   [ ] New third-party packages, if any, do not introduce potential security threats
-   [ ] There are no CI changes, or they have been OK’d by the devops team
-   [ ] Code changes have been quality checked in the ephemeral URL
-   [ ] Errors are handled using the right error handles
-   [ ] The right thing is returned
